### PR TITLE
Always have a latest tagged image for practicality

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ jobs:
           docker login -u $DOCKER_USER -p $DOCKER_PASS
           docker build -t magneticio/vampkubist-istio-adapter:$VERSION .
           docker push magneticio/vampkubist-istio-adapter:$VERSION
+          docker tag magneticio/vampkubist-istio-adapter:$VERSION magneticio/vampkubist-istio-adapter:latest
+          docker push magneticio/vampkubist-istio-adapter:latest
 workflows:
   version: 2
   main:


### PR DESCRIPTION
I want to have the latest tagged image for the production similar to dev repository.